### PR TITLE
feat(cli): added --signoff/-s option for Signed-off-by trailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ lgit --dry-run                      # Preview message without committing
 lgit --copy                         # Copy message to clipboard
 lgit -p                             # Commit and push
 lgit -S                             # GPG sign the commit
+lgit -s                             # Add Signed-off-by trailer
 
 # Modes
 lgit --mode=unstaged                # Preview unstaged changes (no commit)
@@ -137,6 +138,10 @@ summary_hard_limit = 128                  # Absolute max
 changelog_enabled = true
 map_reduce_enabled = true                 # Parallel analysis for large commits
 temperature = 0.2
+
+# Commit signing
+gpg_sign = false                          # GPG sign commits by default (-S)
+signoff = false                           # Add Signed-off-by trailer by default (-s)
 ```
 
 ### Provider Examples

--- a/examples/configs/litellm.toml
+++ b/examples/configs/litellm.toml
@@ -36,3 +36,7 @@ temperature = 0.2
 # GPG Signing (set to true to always sign commits)
 # Can also use --sign/-S CLI flag
 gpg_sign = false
+
+# Signed-off-by trailer (set to true to always add)
+# Can also use --signoff/-s CLI flag
+signoff = false

--- a/src/api.rs
+++ b/src/api.rs
@@ -640,7 +640,11 @@ pub fn generate_conventional_analysis<'a>(
             // Find the tool call in the response
             if !message.tool_calls.is_empty() {
                let tool_call = &message.tool_calls[0];
-               if tool_call.function.name.ends_with("create_conventional_analysis") {
+               if tool_call
+                  .function
+                  .name
+                  .ends_with("create_conventional_analysis")
+               {
                   let args = &tool_call.function.arguments;
                   if args.is_empty() {
                      crate::style::warn(

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -404,32 +404,36 @@ fn call_changelog_api(
       if let Ok(api_response) = serde_json::from_str::<ApiResponse>(&response_text) {
          let message = &api_response.choices[0].message;
 
-        // Check for tool calls (OpenAI format)
-        if !message.tool_calls.is_empty() {
-           let tool_call = &message.tool_calls[0];
-           if tool_call.function.name.ends_with("create_changelog_entries") {
-              let changelog_response: ChangelogResponse =
-                 serde_json::from_str(&tool_call.function.arguments).map_err(|e| {
-                    CommitGenError::Other(format!(
-                       "Failed to parse changelog tool arguments: {e}. Args: {}",
-                       tool_call
-                          .function
-                          .arguments
-                          .chars()
-                          .take(500)
-                          .collect::<String>()
-                    ))
-                 })?;
-              return Ok(changelog_response);
-           }
-        }
+         // Check for tool calls (OpenAI format)
+         if !message.tool_calls.is_empty() {
+            let tool_call = &message.tool_calls[0];
+            if tool_call
+               .function
+               .name
+               .ends_with("create_changelog_entries")
+            {
+               let changelog_response: ChangelogResponse =
+                  serde_json::from_str(&tool_call.function.arguments).map_err(|e| {
+                     CommitGenError::Other(format!(
+                        "Failed to parse changelog tool arguments: {e}. Args: {}",
+                        tool_call
+                           .function
+                           .arguments
+                           .chars()
+                           .take(500)
+                           .collect::<String>()
+                     ))
+                  })?;
+               return Ok(changelog_response);
+            }
+         }
 
          // Fallback: try content field (for models that don't support function calling)
          if let Some(content) = &message.content {
             let json_str = extract_json_from_content(content);
             if !json_str.is_empty() {
-               let changelog_response: ChangelogResponse =
-                  serde_json::from_str(&json_str).map_err(|e| {
+               let changelog_response: ChangelogResponse = serde_json::from_str(&json_str)
+                  .map_err(|e| {
                      CommitGenError::Other(format!(
                         "Failed to parse changelog response from content: {e}. Content: {}",
                         json_str.chars().take(500).collect::<String>()
@@ -443,12 +447,10 @@ fn call_changelog_api(
       // Last resort: try to extract JSON from raw response
       let json_str = extract_json_from_content(&response_text);
       if json_str.is_empty() {
-         return Err(CommitGenError::Other(
-            format!(
-               "Changelog API returned no tool calls or parseable content. Raw response: {}",
-               response_text.chars().take(1000).collect::<String>()
-            ),
-         ));
+         return Err(CommitGenError::Other(format!(
+            "Changelog API returned no tool calls or parseable content. Raw response: {}",
+            response_text.chars().take(1000).collect::<String>()
+         )));
       }
       let changelog_response: ChangelogResponse = serde_json::from_str(&json_str).map_err(|e| {
          CommitGenError::Other(format!(

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -408,7 +408,7 @@ pub fn analyze_for_compose(
       let message = &choice.message;
 
       if let Some(tool_call) = message.tool_calls.first()
-          && tool_call.function.name.ends_with("create_compose_analysis")
+         && tool_call.function.name.ends_with("create_compose_analysis")
       {
          let args = &tool_call.function.arguments;
          match parse_compose_groups_from_json(args) {
@@ -814,7 +814,8 @@ pub fn execute_compose(
       // Create commit (unless preview mode)
       if !args.compose_preview {
          let sign = args.sign || config.gpg_sign;
-         git_commit(&formatted_message, false, dir, sign, args.skip_hooks)?;
+         let signoff = args.signoff || config.signoff;
+         git_commit(&formatted_message, false, dir, sign, signoff, args.skip_hooks)?;
          let hash = get_head_hash(dir)?;
          commit_hashes.push(hash);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,11 @@ pub struct CommitConfig {
    #[serde(default = "default_gpg_sign")]
    pub gpg_sign: bool,
 
+   /// Add Signed-off-by trailer by default (can be overridden by --signoff CLI
+   /// flag)
+   #[serde(default = "default_signoff")]
+   pub signoff: bool,
+
    /// Commit types with descriptions for AI prompts (order = priority)
    #[serde(default = "default_types")]
    pub types: IndexMap<String, TypeConfig>,
@@ -141,6 +146,10 @@ const fn default_gpg_sign() -> bool {
    false
 }
 
+const fn default_signoff() -> bool {
+   false
+}
+
 const fn default_changelog_enabled() -> bool {
    true
 }
@@ -184,41 +193,41 @@ impl Default for CommitConfig {
          temperature:             0.2, // Low temperature for consistent structured output
          model:                   "claude-opus-4.5".to_string(),
          excluded_files:          vec![
-           // Rust
+            // Rust
             "Cargo.lock".to_string(),
-           // JavaScript/Node
+            // JavaScript/Node
             "package-lock.json".to_string(),
-           "npm-shrinkwrap.json".to_string(),
+            "npm-shrinkwrap.json".to_string(),
             "yarn.lock".to_string(),
             "pnpm-lock.yaml".to_string(),
-           "shrinkwrap.yaml".to_string(),
+            "shrinkwrap.yaml".to_string(),
             "bun.lock".to_string(),
             "bun.lockb".to_string(),
-           "deno.lock".to_string(),
-           // PHP
+            "deno.lock".to_string(),
+            // PHP
             "composer.lock".to_string(),
-           // Ruby
+            // Ruby
             "Gemfile.lock".to_string(),
-           // Python
+            // Python
             "poetry.lock".to_string(),
-           "Pipfile.lock".to_string(),
-           "pdm.lock".to_string(),
-           "uv.lock".to_string(),
-           // Go
-           "go.sum".to_string(),
-           // Nix
+            "Pipfile.lock".to_string(),
+            "pdm.lock".to_string(),
+            "uv.lock".to_string(),
+            // Go
+            "go.sum".to_string(),
+            // Nix
             "flake.lock".to_string(),
-           // Dart/Flutter
-           "pubspec.lock".to_string(),
-           // iOS/macOS
-           "Podfile.lock".to_string(),
-           "Packages.resolved".to_string(),
-           // Elixir
-           "mix.lock".to_string(),
-           // .NET
-           "packages.lock.json".to_string(),
-           // Gradle
-           "gradle.lockfile".to_string(),
+            // Dart/Flutter
+            "pubspec.lock".to_string(),
+            // iOS/macOS
+            "Podfile.lock".to_string(),
+            "Packages.resolved".to_string(),
+            // Elixir
+            "mix.lock".to_string(),
+            // .NET
+            "packages.lock.json".to_string(),
+            // Gradle
+            "gradle.lockfile".to_string(),
          ],
          low_priority_extensions: vec![
             ".lock".to_string(),
@@ -239,6 +248,7 @@ impl Default for CommitConfig {
          wide_change_abstract:    default_wide_change_abstract(),
          exclude_old_message:     default_exclude_old_message(),
          gpg_sign:                default_gpg_sign(),
+         signoff:                 default_signoff(),
          types:                   default_types(),
          classifier_hint:         default_classifier_hint(),
          categories:              default_categories(),

--- a/src/git.rs
+++ b/src/git.rs
@@ -229,18 +229,23 @@ pub fn get_git_stat(
 }
 
 /// Execute git commit with the given message
+#[allow(clippy::fn_params_excessive_bools, reason = "commit flags are naturally boolean")]
 pub fn git_commit(
    message: &str,
    dry_run: bool,
    dir: &str,
    sign: bool,
+   signoff: bool,
    skip_hooks: bool,
 ) -> Result<()> {
    if dry_run {
       let sign_flag = if sign { " -S" } else { "" };
+      let signoff_flag = if signoff { " -s" } else { "" };
       let hooks_flag = if skip_hooks { " --no-verify" } else { "" };
-      let command =
-         format!("git commit{sign_flag}{hooks_flag} -m \"{}\"", message.replace('\n', "\\n"));
+      let command = format!(
+         "git commit{sign_flag}{signoff_flag}{hooks_flag} -m \"{}\"",
+         message.replace('\n', "\\n")
+      );
       println!("\n{}", style::boxed_message("DRY RUN", &command, 60));
       return Ok(());
    }
@@ -248,6 +253,9 @@ pub fn git_commit(
    let mut args = vec!["commit"];
    if sign {
       args.push("-S");
+   }
+   if signoff {
+      args.push("-s");
    }
    if skip_hooks {
       args.push("--no-verify");

--- a/src/main.rs
+++ b/src/main.rs
@@ -705,7 +705,8 @@ fn main() -> Result<()> {
 
       println!("\n{}", style::info("Preparing to commit..."));
       let sign = args.sign || config.gpg_sign;
-      git_commit(&formatted_message, args.dry_run, &args.dir, sign, args.skip_hooks)?;
+      let signoff = args.signoff || config.signoff;
+      git_commit(&formatted_message, args.dry_run, &args.dir, sign, signoff, args.skip_hooks)?;
 
       // Auto-push if requested (only if not dry-run)
       if args.push && !args.dry_run {

--- a/src/map_reduce.rs
+++ b/src/map_reduce.rs
@@ -695,7 +695,11 @@ pub fn reduce_phase(
 
             if !message.tool_calls.is_empty() {
                let tool_call = &message.tool_calls[0];
-               if tool_call.function.name.ends_with("create_conventional_analysis") {
+               if tool_call
+                  .function
+                  .name
+                  .ends_with("create_conventional_analysis")
+               {
                   let args = &tool_call.function.arguments;
                   if args.is_empty() {
                      return Err(CommitGenError::Other(

--- a/src/types.rs
+++ b/src/types.rs
@@ -964,6 +964,10 @@ pub struct Args {
    #[arg(long, short = 'S')]
    pub sign: bool,
 
+   /// Add Signed-off-by trailer (equivalent to git commit -s)
+   #[arg(long, short = 's')]
+   pub signoff: bool,
+
    /// Skip pre-commit and commit-msg hooks (equivalent to git commit
    /// --no-verify)
    #[arg(long, short = 'n')]
@@ -1087,6 +1091,7 @@ impl Default for Args {
          refs:                    vec![],
          breaking:                false,
          sign:                    false,
+         signoff:                 false,
          skip_hooks:              false,
          config:                  None,
          context:                 vec![],


### PR DESCRIPTION
- Added -s/--signoff CLI argument in types.rs for adding Signed-off-by trailer to commits, mirroring git commit -s behavior.
- Added signoff configuration option in config.rs with default value of false, allowing users to enable signoff by default.
- Extended git_commit() function signature in git.rs to accept signoff parameter and pass -s flag to git command.
- Updated dry-run output to display -s flag when signoff is enabled.
- Updated main.rs and compose.rs to resolve signoff from CLI args or config and pass to git_commit().
- Updated README.md with -s usage example and signoff configuration documentation.
- Added signoff option to examples/configs/litellm.toml as reference.