### PR TITLE
Add pipe mode with auto-detection for stdout redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ lgit --copy                         # Copy message to clipboard
 lgit -p                             # Commit and push
 lgit -S                             # GPG sign the commit
 lgit -s                             # Add Signed-off-by trailer
+lgit | git commit -F -              # Pipe mode (auto-detected, for SSH/headless)
 
 # Modes
 lgit --mode=unstaged                # Preview unstaged changes (no commit)

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -382,9 +382,7 @@ pub fn extract_scope_candidates(
             .args(["show", "--numstat", target])
             .current_dir(dir)
             .output()
-            .map_err(|e| {
-               CommitGenError::git(format!("Failed to run git show --numstat: {e}"))
-            })?
+            .map_err(|e| CommitGenError::git(format!("Failed to run git show --numstat: {e}")))?
       },
       Mode::Unstaged => Command::new("git")
          .args(["diff", "--numstat"])

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -533,9 +533,7 @@ fn get_staged_files(dir: &str) -> Result<Vec<String>> {
 
    if !output.status.success() {
       let stderr = String::from_utf8_lossy(&output.stderr);
-      return Err(CommitGenError::git(format!(
-         "git diff --cached --name-only failed: {stderr}"
-      )));
+      return Err(CommitGenError::git(format!("git diff --cached --name-only failed: {stderr}")));
    }
 
    let files: Vec<String> = String::from_utf8_lossy(&output.stdout)

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -190,7 +190,7 @@ fn parse_compose_groups_from_content(content: &str) -> Result<Vec<ChangeGroup>> 
          let mut lines = block.lines();
          let first_line = lines.next().unwrap_or_default();
 
-         let mut owned_candidate: Option<String> = None;
+         let rest_owned: String;
          let json_candidate = if first_line.trim_start().starts_with('{') {
             block
          } else {
@@ -199,8 +199,8 @@ fn parse_compose_groups_from_content(content: &str) -> Result<Vec<ChangeGroup>> 
             if trimmed_rest.is_empty() {
                block
             } else {
-               owned_candidate = Some(trimmed_rest.to_string());
-               owned_candidate.as_deref().unwrap()
+               rest_owned = trimmed_rest.to_string();
+               &rest_owned
             }
          };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,9 +21,7 @@ pub enum CommitGenError {
       code(lgit::git::index_locked),
       help("Another git process may be running in this repository.\nRemove the lock file to continue:\n  rm {}", lock_path.display()),
    )]
-   GitIndexLocked {
-      lock_path: PathBuf,
-   },
+   GitIndexLocked { lock_path: PathBuf },
 
    #[error("API request failed (HTTP {status}): {body}")]
    #[diagnostic(code(lgit::api))]
@@ -32,7 +30,10 @@ pub enum CommitGenError {
    #[error("API call failed after {retries} retries")]
    #[diagnostic(
       code(lgit::api::retry_exhausted),
-      help("Check that your LiteLLM server is running and reachable.\nYou can increase max_retries in ~/.config/llm-git/config.toml"),
+      help(
+         "Check that your LiteLLM server is running and reachable.\nYou can increase max_retries \
+          in ~/.config/llm-git/config.toml"
+      )
    )]
    ApiRetryExhausted {
       retries: u32,
@@ -47,7 +48,7 @@ pub enum CommitGenError {
    #[error("No changes found in {mode} mode")]
    #[diagnostic(
       code(lgit::git::no_changes),
-      help("Stage changes with `git add` or use --mode=unstaged to analyze working tree changes"),
+      help("Stage changes with `git add` or use --mode=unstaged to analyze working tree changes")
    )]
    NoChanges { mode: String },
 
@@ -59,14 +60,14 @@ pub enum CommitGenError {
    #[error("Invalid commit type: {0}")]
    #[diagnostic(
       code(lgit::types::commit_type),
-      help("Valid types: feat, fix, refactor, docs, test, chore, style, perf, build, ci, revert"),
+      help("Valid types: feat, fix, refactor, docs, test, chore, style, perf, build, ci, revert")
    )]
    InvalidCommitType(String),
 
    #[error("Invalid scope format: {0}")]
    #[diagnostic(
       code(lgit::types::scope),
-      help("Scopes must be lowercase alphanumeric with at most 2 segments (e.g. api/client)"),
+      help("Scopes must be lowercase alphanumeric with at most 2 segments (e.g. api/client)")
    )]
    InvalidScope(String),
 
@@ -100,7 +101,7 @@ pub enum CommitGenError {
    #[error("No [Unreleased] section found in {path}")]
    #[diagnostic(
       code(lgit::changelog::no_unreleased),
-      help("Add an ## [Unreleased] section to the changelog file"),
+      help("Add an ## [Unreleased] section to the changelog file")
    )]
    NoUnreleasedSection { path: String },
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -23,7 +23,11 @@ fn check_index_lock(stderr: &str, dir: &str) -> Option<CommitGenError> {
          let start = line.find('\'')?;
          let end = line[start + 1..].find('\'')?;
          let path = &line[start + 1..start + 1 + end];
-         if path.ends_with("index.lock") { Some(PathBuf::from(path)) } else { None }
+         if path.ends_with("index.lock") {
+            Some(PathBuf::from(path))
+         } else {
+            None
+         }
       })
       .unwrap_or_else(|| PathBuf::from(dir).join(".git/index.lock"));
 
@@ -52,9 +56,7 @@ pub fn ensure_git_repo(dir: &str) -> Result<()> {
       ));
    }
 
-   Err(CommitGenError::git(format!(
-      "Failed to detect git repository: {stderr}"
-   )))
+   Err(CommitGenError::git(format!("Failed to detect git repository: {stderr}")))
 }
 
 /// Get git diff based on the specified mode
@@ -104,9 +106,7 @@ pub fn get_git_diff(
             .args(["ls-files", "--others", "--exclude-standard"])
             .current_dir(dir)
             .output()
-            .map_err(|e| {
-               CommitGenError::git(format!("Failed to list untracked files: {e}"))
-            })?;
+            .map_err(|e| CommitGenError::git(format!("Failed to list untracked files: {e}")))?;
 
          if !untracked_output.status.success() {
             let stderr = String::from_utf8_lossy(&untracked_output.stderr);
@@ -231,9 +231,7 @@ pub fn get_git_stat(
             .args(["ls-files", "--others", "--exclude-standard"])
             .current_dir(dir)
             .output()
-            .map_err(|e| {
-               CommitGenError::git(format!("Failed to list untracked files: {e}"))
-            })?;
+            .map_err(|e| CommitGenError::git(format!("Failed to list untracked files: {e}")))?;
 
          if !untracked_output.status.success() {
             let stderr = String::from_utf8_lossy(&untracked_output.stderr);

--- a/src/main.rs
+++ b/src/main.rs
@@ -597,26 +597,25 @@ fn main() -> miette::Result<()> {
             .args(["diff", "--quiet"])
             .current_dir(&args.dir)
             .status()
-            .map_err(|e| {
-               CommitGenError::git(format!("Failed to check unstaged changes: {e}"))
-            })?;
+            .map_err(|e| CommitGenError::git(format!("Failed to check unstaged changes: {e}")))?;
 
          // Check for untracked files
          let untracked_output = Command::new("git")
             .args(["ls-files", "--others", "--exclude-standard"])
             .current_dir(&args.dir)
             .output()
-            .map_err(|e| {
-               CommitGenError::git(format!("Failed to check untracked files: {e}"))
-            })?;
+            .map_err(|e| CommitGenError::git(format!("Failed to check untracked files: {e}")))?;
 
          let has_untracked = !untracked_output.stdout.is_empty();
 
          // If no unstaged changes AND no untracked files, working directory is clean
          if unstaged_check.success() && !has_untracked {
-            return Err((CommitGenError::NoChanges {
-               mode: "working directory (nothing to commit)".to_string(),
-            }).into());
+            return Err(
+               (CommitGenError::NoChanges {
+                  mode: "working directory (nothing to commit)".to_string(),
+               })
+               .into(),
+            );
          }
 
          status!("{} {}", style::info("›"), style::dim("No staged changes, staging all..."));
@@ -679,8 +678,7 @@ fn main() -> miette::Result<()> {
    // Save final commit message if debug output requested
    if let Some(debug_dir) = &args.debug_output {
       save_debug_output(debug_dir, "final.txt", &formatted_message)?;
-      let commit_json =
-         serde_json::to_string_pretty(&commit_msg).map_err(CommitGenError::from)?;
+      let commit_json = serde_json::to_string_pretty(&commit_msg).map_err(CommitGenError::from)?;
       save_debug_output(debug_dir, "commit.json", &commit_json)?;
    }
 
@@ -695,10 +693,7 @@ fn main() -> miette::Result<()> {
 
       if std::env::var("LLM_GIT_VERBOSE").is_ok() {
          println!("\nJSON Structure:");
-         println!(
-            "{}",
-            serde_json::to_string_pretty(&commit_msg).map_err(CommitGenError::from)?
-         );
+         println!("{}", serde_json::to_string_pretty(&commit_msg).map_err(CommitGenError::from)?);
       }
 
       // Copy to clipboard if requested
@@ -720,9 +715,10 @@ fn main() -> miette::Result<()> {
                    commit."
                )
             );
-            return Err(CommitGenError::ValidationError(
-               "Commit message validation failed".to_string(),
-            ).into());
+            return Err(
+               CommitGenError::ValidationError("Commit message validation failed".to_string())
+                  .into(),
+            );
          }
 
          println!("\n{}", style::info("Preparing to commit..."));

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -328,7 +328,7 @@ fn extract_hunks_for_file(
    let mut result = String::new();
    let mut in_header = true;
    let mut current_hunk = String::new();
-   let mut current_hunk_header = String::new();
+   let mut current_hunk_header;
    let mut include_current = false;
 
    for line in file_diff.lines() {


### PR DESCRIPTION
When stdout is piped or redirected (e.g. `lgit | git commit -F -`), pipe mode activates automatically: only the raw commit message goes to stdout, while all progress, spinners, and warnings go to stderr. TTY behavior is unchanged.

- style.rs: added pipe_mode() detection; spinner fallback and warn() now use stderr to prevent escape sequences from leaking into stdout
- main.rs: added status! macro to route status output by mode; pipe mode skips boxed display, clipboard copy, and auto-commit
- Added pipe usage example to README

Why pipe mode matters

Unix tools like `ls`, `git log`, and `grep` all follow the same convention: human-friendly output on terminals, clean data when piped. Without pipe mode, lgit dumped spinners, box-drawing characters, and ANSI escapes into stdout regardless of context, breaking any pipeline usage.

Use cases

Pipe mode enables standard Unix composition. You can generate a message and commit with custom flags (`lgit | git commit --amend -F -`), save it for review (`lgit > msg.txt`), or feed it into other tools. It also makes lgit usable in SSH sessions, headless CI, and editor plugins where stdout is captured rather than displayed.