### PR TITLE
fix(cli): preserved commit and push behavior in pipe mode and add amend flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ lgit --copy                         # Copy message to clipboard
 lgit -p                             # Commit and push
 lgit -S                             # GPG sign the commit
 lgit -s                             # Add Signed-off-by trailer
+lgit --amend                        # Amend the previous commit
 lgit | git commit -F -              # Pipe mode (auto-detected, for SSH/headless)
 
 # Modes

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ lgit -p                             # Commit and push
 lgit -S                             # GPG sign the commit
 lgit -s                             # Add Signed-off-by trailer
 lgit --amend                        # Amend the previous commit
-lgit | git commit -F -              # Pipe mode (auto-detected, for SSH/headless)
+lgit > msg.txt                      # Save raw message to file (auto-detected pipe mode)
+lgit --dry-run | git commit -F -    # Generate message and commit with custom git flags
 
 # Modes
 lgit --mode=unstaged                # Preview unstaged changes (no commit)

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -815,7 +815,7 @@ pub fn execute_compose(
       if !args.compose_preview {
          let sign = args.sign || config.gpg_sign;
          let signoff = args.signoff || config.signoff;
-         git_commit(&formatted_message, false, dir, sign, signoff, args.skip_hooks)?;
+         git_commit(&formatted_message, false, dir, sign, signoff, args.skip_hooks, false)?;
          let hash = get_head_hash(dir)?;
          commit_hashes.push(hash);
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -295,7 +295,11 @@ pub fn git_commit(
          "git commit{sign_flag}{signoff_flag}{hooks_flag}{amend_flag} -m \"{}\"",
          message.replace('\n', "\\n")
       );
-      println!("\n{}", style::boxed_message("DRY RUN", &command, 60));
+      if style::pipe_mode() {
+         eprintln!("\n{}", style::boxed_message("DRY RUN", &command, 60));
+      } else {
+         println!("\n{}", style::boxed_message("DRY RUN", &command, 60));
+      }
       return Ok(());
    }
 
@@ -331,19 +335,32 @@ pub fn git_commit(
    }
 
    let stdout = String::from_utf8_lossy(&output.stdout);
-   println!("\n{stdout}");
-   println!(
-      "{} {}",
-      style::success(style::icons::SUCCESS),
-      style::success("Successfully committed!")
-   );
+   if style::pipe_mode() {
+      eprintln!("\n{stdout}");
+      eprintln!(
+         "{} {}",
+         style::success(style::icons::SUCCESS),
+         style::success("Successfully committed!")
+      );
+   } else {
+      println!("\n{stdout}");
+      println!(
+         "{} {}",
+         style::success(style::icons::SUCCESS),
+         style::success("Successfully committed!")
+      );
+   }
 
    Ok(())
 }
 
 /// Execute git push
 pub fn git_push(dir: &str) -> Result<()> {
-   println!("\n{}", style::info("Pushing changes..."));
+   if style::pipe_mode() {
+      eprintln!("\n{}", style::info("Pushing changes..."));
+   } else {
+      println!("\n{}", style::info("Pushing changes..."));
+   }
 
    let output = Command::new("git")
       .args(["push"])
@@ -361,13 +378,31 @@ pub fn git_push(dir: &str) -> Result<()> {
 
    let stdout = String::from_utf8_lossy(&output.stdout);
    let stderr = String::from_utf8_lossy(&output.stderr);
-   if !stdout.is_empty() {
-      println!("{stdout}");
+   if style::pipe_mode() {
+      if !stdout.is_empty() {
+         eprintln!("{stdout}");
+      }
+      if !stderr.is_empty() {
+         eprintln!("{stderr}");
+      }
+      eprintln!(
+         "{} {}",
+         style::success(style::icons::SUCCESS),
+         style::success("Successfully pushed!")
+      );
+   } else {
+      if !stdout.is_empty() {
+         println!("{stdout}");
+      }
+      if !stderr.is_empty() {
+         println!("{stderr}");
+      }
+      println!(
+         "{} {}",
+         style::success(style::icons::SUCCESS),
+         style::success("Successfully pushed!")
+      );
    }
-   if !stderr.is_empty() {
-      println!("{stderr}");
-   }
-   println!("{} {}", style::success(style::icons::SUCCESS), style::success("Successfully pushed!"));
 
    Ok(())
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -284,13 +284,15 @@ pub fn git_commit(
    sign: bool,
    signoff: bool,
    skip_hooks: bool,
+   amend: bool,
 ) -> Result<()> {
    if dry_run {
       let sign_flag = if sign { " -S" } else { "" };
       let signoff_flag = if signoff { " -s" } else { "" };
       let hooks_flag = if skip_hooks { " --no-verify" } else { "" };
+      let amend_flag = if amend { " --amend" } else { "" };
       let command = format!(
-         "git commit{sign_flag}{signoff_flag}{hooks_flag} -m \"{}\"",
+         "git commit{sign_flag}{signoff_flag}{hooks_flag}{amend_flag} -m \"{}\"",
          message.replace('\n', "\\n")
       );
       println!("\n{}", style::boxed_message("DRY RUN", &command, 60));
@@ -306,6 +308,9 @@ pub fn git_commit(
    }
    if skip_hooks {
       args.push("--no-verify");
+   }
+   if amend {
+      args.push("--amend");
    }
    args.push("-m");
    args.push(message);

--- a/src/main.rs
+++ b/src/main.rs
@@ -724,7 +724,7 @@ fn main() -> miette::Result<()> {
          println!("\n{}", style::info("Preparing to commit..."));
          let sign = args.sign || config.gpg_sign;
          let signoff = args.signoff || config.signoff;
-         git_commit(&formatted_message, args.dry_run, &args.dir, sign, signoff, args.skip_hooks)?;
+         git_commit(&formatted_message, args.dry_run, &args.dir, sign, signoff, args.skip_hooks, args.amend)?;
 
          // Auto-push if requested (only if not dry-run)
          if args.push && !args.dry_run {

--- a/src/types.rs
+++ b/src/types.rs
@@ -968,6 +968,10 @@ pub struct Args {
    #[arg(long, short = 's')]
    pub signoff: bool,
 
+   /// Amend the previous commit (equivalent to git commit --amend)
+   #[arg(long)]
+   pub amend: bool,
+
    /// Skip pre-commit and commit-msg hooks (equivalent to git commit
    /// --no-verify)
    #[arg(long, short = 'n')]
@@ -1092,6 +1096,7 @@ impl Default for Args {
          breaking:                false,
          sign:                    false,
          signoff:                 false,
+         amend:                   false,
          skip_hooks:              false,
          config:                  None,
          context:                 vec![],


### PR DESCRIPTION
Thanks for the feedback. You're right that common operations like amend should be first class flags, so I added --amend in a follow up. 

On pipe mode: I realized the original implementation had a real problem. It was silently skipping commit and clipboard when stdout was redirected, which means lgit > build.log would stop committing with no warning. That's not acceptable.

I've fixed it so pipe mode only affects output format (raw message to stdout, progress to stderr), while commit, clipboard, and push still work exactly as requested by flags. The main use case is non-TTY environments (SSH sessions, editor plugins, CI) where ANSI escapes and spinners in stdout cause problems.