### PR TITLE
fix: use string tool_choice for LM Studio compatibility

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -565,9 +565,7 @@ pub async fn generate_conventional_analysis<'a>(
                max_tokens:       1000,
                temperature:      config.temperature,
                tools:            vec![tool],
-               tool_choice:      Some(
-                  serde_json::json!({ "type": "function", "function": { "name": "create_conventional_analysis" } }),
-               ),
+                  tool_choice:      Some(serde_json::json!("required")),
                prompt_cache_key,
                messages:         vec![
                   Message { role: "system".to_string(), content: parts.system },
@@ -1072,10 +1070,7 @@ pub async fn generate_summary_from_analysis<'a>(
                   max_tokens:       200,
                   temperature:      config.temperature,
                   tools:            vec![tool],
-                  tool_choice:      Some(serde_json::json!({
-                     "type": "function",
-                     "function": { "name": "create_commit_summary" }
-                  })),
+                  tool_choice:      Some(serde_json::json!("required")),
                   prompt_cache_key,
                   messages:         vec![
                      Message { role: "system".to_string(), content: parts.system },
@@ -1667,9 +1662,7 @@ pub async fn generate_fast_commit(
                max_tokens:       500,
                temperature:      config.temperature,
                tools:            vec![tool],
-               tool_choice:      Some(
-                  serde_json::json!({ "type": "function", "function": { "name": "create_fast_commit" } }),
-               ),
+               tool_choice:      Some(serde_json::json!("required")),
                prompt_cache_key,
                messages:         vec![
                   Message { role: "system".to_string(), content: parts.system },

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -352,9 +352,7 @@ async fn call_changelog_api(
          max_tokens: 2000,
          temperature: config.temperature,
          tools: vec![tool.clone()],
-         tool_choice: Some(
-            serde_json::json!({ "type": "function", "function": { "name": "create_changelog_entries" } }),
-         ),
+         tool_choice: Some(serde_json::json!("required")),
          prompt_cache_key,
          messages,
       };

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -367,9 +367,7 @@ pub async fn analyze_for_compose(
       max_tokens: 8000,
       temperature: config.temperature,
       tools: vec![tool],
-      tool_choice: Some(
-         serde_json::json!({ "type": "function", "function": { "name": "create_compose_analysis" } }),
-      ),
+      tool_choice: Some(serde_json::json!("required")),
       prompt_cache_key,
       messages: vec![
          Message { role: "system".to_string(), content: COMPOSE_SYSTEM_PROMPT.to_string() },

--- a/src/map_reduce.rs
+++ b/src/map_reduce.rs
@@ -1237,8 +1237,7 @@ fn build_api_request(
       model: model.to_string(),
       max_tokens: 1500,
       temperature,
-      tool_choice: tool_name
-         .map(|name| serde_json::json!({ "type": "function", "function": { "name": name } })),
+      tool_choice: tool_name.map(|_| serde_json::json!("required")),
       prompt_cache_key,
       tools,
       messages,


### PR DESCRIPTION
## Summary

Fix OpenAI-compatible tool calls for LM Studio.

LM Studio rejects object-form `tool_choice` values like:

`json
{ "type": "function", "function": { "name": "..." } }
`

and only accepts string values such as `none`, `auto`, or `required`.

## What changed

For OpenAI-compatible requests that already send exactly one tool, this PR uses:

`json
"tool_choice": "required"
`

instead of the object form naming the function.

## Why

This preserves function-calling behavior while making `llm-git` work with LM Studio's OpenAI-compatible API.

Closes #13

## Scope

This updates the single-tool request builders in:

- `src/api.rs`
- `src/compose.rs`
- `src/changelog.rs`
- `src/map_reduce.rs`

## Validation

Validated locally against LM Studio by:

1. Pointing `llm-git` at an LM Studio OpenAI-compatible endpoint.
2. Reproducing the original HTTP 400 failure.
3. Applying this change.
4. Verifying `lgit --dry-run` succeeds and generates a commit message.

## Notes

This is a minimal compatibility fix. If you prefer, this behavior could later be made provider-specific, but this change keeps the fix small and directly addresses the incompatibility.
